### PR TITLE
Update regular expression to get device id

### DIFF
--- a/android.js
+++ b/android.js
@@ -93,7 +93,7 @@ var Android = {
     verbose('start(' + avdName + ')');
     return spawnWaitFor(
       'emulator -verbose -avd "' + avdName + '"',
-      /emulator: control console listening on port (\d+), ADB on port \d+/
+      /emulator: Serial number of this emulator \(for ADB\): emulator-(\d+)/
     ).then(function(result) {
       return {
         process: result.process,

--- a/spec/android-start-or-create-spec.js
+++ b/spec/android-start-or-create-spec.js
@@ -15,10 +15,10 @@ describe('Android', function() {
       var obj = {
         process: fakeProcess = {},
         matches: [
-          'emulator: control console listening on port (5554), ADB on port 5555',
+          'emulator: Serial number of this emulator (for ADB): emulator-5554',
           '5554',
         ],
-        line: 'emulator: control console listening on port (5554), ADB on port 5555',
+        line: 'emulator: Serial number of this emulator (for ADB): emulator-5554',
       };
 
       return bluebird.resolve(obj);


### PR DESCRIPTION
This updates the regular expression on `start` method that is used to get the device id. Otherwise the promise will never be resolved so it is not possible to ensure the device is ready.